### PR TITLE
chore(deps): refresh the stale lockfile

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -68,6 +68,7 @@
       "integrity": "a917ffdeb5924c9be436dc78bc32e511760e14d3a96e49c607fc5ecca86d0092",
       "dependencies": [
         "jsr:@std/assert",
+        "jsr:@std/async",
         "jsr:@std/data-structures",
         "jsr:@std/fs",
         "jsr:@std/internal@^1.0.12",


### PR DESCRIPTION
## Summary

Unblocks the Release job on main, which failed at `deno ci` with:

```
error: The lockfile is out of date. Run `deno install --frozen=false`, or rerun with `--frozen=false` to update it.
```

`@std/testing`'s lock entry was missing its `jsr:@std/async` dependency — a one-line omission.

**This predates the release workflow.** The same frozen install fails on `d9fc4c7`, before any of #8's commits. It went unnoticed because the old `publish.yml` ran `npx jsr publish` and never installed from the lock; the new release job runs `deno ci`, which is frozen, so it was the first thing to check.

## Also fixed outside this PR: the missing tag baseline

The repo had **zero git tags**, so semantic-release would have treated its first run as an initial release and published **1.0.0**, not the 0.4.0 that #8's `feat:` commit implies.

I've pushed a `0.3.0` tag at `d9fc4c7` — the commit whose `deno.json` says `0.3.0`, matching JSR's current latest. With that baseline in place, semantic-release analyses commits since 0.3.0, finds `feat: make less, sass, and stylus optional`, and cuts **0.4.0**.

No change was needed for the merge commit itself: merging #8 with a merge commit preserved both underlying commits on main, so the `feat:` commit is still there to be analysed.

## Testing

`deno install --frozen` passes. Full suite green — 6 passed, 0 failed.